### PR TITLE
Add a note about render views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,3 @@
-# README
+**A note on testing views**
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+In an effort to keep this repo simple to set up and run, we have not added any tools for integration testing, such as Capybara. If you do want to make assertions about what is rendered, it may be helpful to use [Rspec's `render_views` macro](https://relishapp.com/rspec/rspec-rails/v/3-9/docs/controller-specs/render-views#render-views-on-and-off-in-nested-groups).


### PR DESCRIPTION
Trying to test views has tripped some candidates up. This adds a note about using `render_views` to avoid that confusion.

My one concern with this note is that, since it's the only thing in the README, it might frame how candidate thinks about or approaches a solution. 