### PR TITLE
Dockerize for windows too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN gem install bundler
 ADD Gemfile /myapp/Gemfile
 ADD Gemfile.lock /myapp/Gemfile.lock
 ADD package.json /myapp/package.json
+ADD yarn.lock /myapp/yarn.lock
 
 RUN bundle install
 RUN yarn install

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'puma', '~> 4.1'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 5.x'
+gem 'foreman'
 
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
     ffi (1.13.1)
+    foreman (0.87.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.5)
@@ -226,6 +227,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   database_cleaner
   factory_bot_rails
+  foreman
   jbuilder (~> 2.7)
   listen (~> 3.2)
   puma (~> 4.1)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+webpacker: ./bin/webpack-dev-server --inline true
+rails: bin/rails s -p 3000 -b '0.0.0.0'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ You can see question and response activity at `http://localhost:3000/dashboard`
 
 You can also view the React version of the dashboard at `http://localhost:3000/react-dashboard`
 
+** Helpful Docker things
+* `docker-compose run web <command>` to run an arbitrary command in the running container named `web`
+* `docker ps` to see a list of running containers
+* `docker exec -it <container ID> /bin/bash` to get a command prompt in a running container (use `docker ps` to see container IDs)
+
 **A note on testing views**
 
 In an effort to keep this repo simple to set up and run, we have not added any tools for integration testing, such as Capybara. If you do want to make assertions about what is rendered, it may be helpful to use [Rspec's `render_views` macro](https://relishapp.com/rspec/rspec-rails/v/3-9/docs/controller-specs/render-views#render-views-on-and-off-in-nested-groups).

--- a/app/javascript/components/ReactDashboard.js
+++ b/app/javascript/components/ReactDashboard.js
@@ -3,7 +3,7 @@ import React from "react";
 export const ReactDashboard = () => {
   return (
     <div>
-    <h1>Dashboard- - - - </h1>
+    <h1>Dashboard</h1>
 
     <h2>Number of responses from Abraham Lincoln: </h2>
 
@@ -12,7 +12,7 @@ export const ReactDashboard = () => {
     <div className="grid">
       <div className="column">
         <h2>10 most recent responses</h2>
-        <div class="response-card">
+        <div className="response-card">
           <h3>Question Label</h3>
           <p><strong>Responder: </strong></p>
           <p><strong>Response: </strong></p>

--- a/app/javascript/components/ReactDashboard.js
+++ b/app/javascript/components/ReactDashboard.js
@@ -3,7 +3,7 @@ import React from "react";
 export const ReactDashboard = () => {
   return (
     <div>
-    <h1>Dashboard</h1>
+    <h1>Dashboard- - - - </h1>
 
     <h2>Number of responses from Abraham Lincoln: </h2>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,5 +57,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -71,6 +71,7 @@ development:
       'Access-Control-Allow-Origin': '*'
     watch_options:
       ignored: '**/node_modules/**'
+      poll: true
 
 
 test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,14 @@
 version: '3'
 services:
-  webpack-dev-server:
-    build: .
-    environment:
-      - NODE_ENV=development
-      - RAILS_ENV=development
-      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
-    command: bin/webpack-dev-server
-    volumes:
-      - .:/myapp
-    ports: 
-      - "3035:3035"
-    networks: 
-      - "default"
   web:
     build: .
     environment:
-      - WEBPACKER_DEV_SERVER_HOST=webpack-dev-server
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec foreman start"
     volumes:
       - .:/myapp
     ports:
       - "3000:3000"
+      - "3035:3035"
     networks: 
       - "default"


### PR DESCRIPTION
Simplifies the setup to use Foreman to launch webpack-dev-server and Rails in the same container rather than separate containers. Credit to @talk2MeGooseman for that pro tip.

Also adds polling for both Rails and JS changes (especially needed on Windows).