### PR TITLE
Update mimemagic to 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       mimemagic (~> 0.3.2)
     maruku (0.7.3)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)


### PR DESCRIPTION
0.3.5 was yanked from rubygems by the gem's author, making it impossible to bundle install with the existing Gemfile.lock

https://github.com/rails/rails/issues/41750